### PR TITLE
Set correct ID generation strategy; Remove duplicated XML descriptors;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.settings/
+target/
+.project
+.classpath
+

--- a/src/main/java/ua/ustiuhova/entity/PersonEntity.java
+++ b/src/main/java/ua/ustiuhova/entity/PersonEntity.java
@@ -6,24 +6,23 @@ import javax.persistence.*;
  * Created by admin on 05.11.2017.
  */
 @Entity
-@Table(name = "person", schema = "tryhibernate", catalog = "")
+@Table(name = "person")
 public class PersonEntity {
-    private int id;
+    private Integer id;
     private String fio;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(name = "id", nullable = false)
-    public int getId() {
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    public Integer getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 
     @Basic
-    @Column(name = "fio", nullable = true, length = 30)
+    @Column(name = "fio", length = 30)
     public String getFio() {
         return fio;
     }

--- a/src/main/java/ua/ustiuhova/main/Main.java
+++ b/src/main/java/ua/ustiuhova/main/Main.java
@@ -3,6 +3,7 @@ package ua.ustiuhova.main;
 import org.hibernate.Session;
 import ua.ustiuhova.entity.PersonEntity;
 
+import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -14,18 +15,23 @@ public class Main {
     public static void main(String[] args) {
         Session session = HibernateSessionFactory.getSessionFactory().openSession();
         session.beginTransaction();
+
         List<PersonEntity> list = new LinkedList<>();
+
         PersonEntity personEntity = new PersonEntity();
         personEntity.setFio("Person 1");
         list.add(personEntity);
+
         PersonEntity anotherPerson = new PersonEntity();
         anotherPerson.setFio("Person 2");
         list.add(anotherPerson);
+
         for (PersonEntity person : list) {
-            session.save(person);
+            Serializable id = session.save(person);
+            System.out.println("Generated PK = " + id);
         }
+
         session.getTransaction().commit();
         session.close();
-        return;
     }
 }

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -8,10 +8,11 @@
         <property name="connection.username">root</property>
         <property name="connection.password">1111</property>
         <property name="connection.driver_class">com.mysql.jdbc.Driver</property>
+        <property name="hibernate.show_sql">true</property>
         <mapping class="ua.ustiuhova.entity.PersonEntity"/>
-        <mapping resource="PersonEntity.hbm.xml"/>
+        <!-- <mapping resource="PersonEntity.hbm.xml"/> -->
         <mapping class="ua.ustiuhova.entity.PhonesEntity"/>
-        <mapping resource="PhonesEntity.hbm.xml"/>
+        <!-- <mapping resource="PhonesEntity.hbm.xml"/> -->
         <!-- DB schema will be updated if needed -->
         <!-- <property name="hbm2ddl.auto">update</property> -->
     </session-factory>


### PR DESCRIPTION
Что было сделано:
1) Стратегия для генерации
`/**
 * Indicates that the persistence provider must assign
 * primary keys for the entity using a database identity column.
 */
IDENTITY`

2) Убрал XML описания Entity. XML более приоритетный чем аннотации.
http://docs.jboss.org/hibernate/orm/5.2/userguide/html_single/Hibernate_User_Guide.html#bootstrap-jpa-xml-files

"This is possible because if there are two conflicting mappings, the XML mappings takes precedence over its annotation counterpart."
